### PR TITLE
Update AfsAPI in Paddlebox

### DIFF
--- a/paddle/fluid/framework/fleet/box_wrapper.cu
+++ b/paddle/fluid/framework/fleet/box_wrapper.cu
@@ -52,11 +52,11 @@ __global__ void PullCopy(float** dest, const boxps::FeatureValueGpu* src,
       *(dest[x] + y * hidden + 2) = (src + i)->embed_w;
     }
     if ((src + i)->embedding_size == 0 || *(keys[x] + y) == 0) {
-      for (int j = 0; j < 8; j++) {
+      for (int j = 0; j < hidden - 3; j++) {
         *(dest[x] + y * hidden + 3 + j) = 0;
       }
     } else {
-      for (int j = 0; j < 8; j++) {
+      for (int j = 0; j < hidden - 3; j++) {
         *(dest[x] + y * hidden + 3 + j) = (src + i)->embedx[1 + j];
       }
     }
@@ -101,7 +101,7 @@ __global__ void PushCopy(boxps::FeaturePushValueGpu* dest, float** src,
     (dest + i)->show = *(src[x] + y * hidden);
     (dest + i)->clk = *(src[x] + y * hidden + 1);
     (dest + i)->embed_g = *(src[x] + y * hidden + 2) * -1. * bs;
-    for (int j = 0; j < 8; j++) {
+    for (int j = 0; j < hidden - 3; j++) {
       (dest + i)->embedx_g[j] = *(src[x] + y * hidden + 3 + j) * -1. * bs;
     }
   }

--- a/paddle/fluid/framework/fleet/box_wrapper.h
+++ b/paddle/fluid/framework/fleet/box_wrapper.h
@@ -190,14 +190,15 @@ class AfsManager {
     PADDLE_ENFORCE_GE(ret, 0, platform::errors::PreconditionNotMet(
                                   "Called AFSAPI Open Failed."));
 
-    char* _buff = static_cast<char*>(calloc(BUF_SIZE + 2, sizeof(char)));
+    // char* _buff = static_cast<char*>(calloc(BUF_SIZE + 2, sizeof(char)));
+    char _buff[BUF_SIZE];
     int size = 0;
     while ((size = read_stream->Read(_buff, BUF_SIZE)) > 0) {
       fwrite(_buff, 1, size, wfp);
     }
     fflush(wfp);
     fclose(wfp);
-    delete _buff;
+    // delete _buff;
     delete read_stream;
   }
   int PopenBidirectionalInternal(const char* command,


### PR DESCRIPTION
AfsAPI dosen't support reading compress file(.gz) directly.
Therefore this PR we use GZFileReader(support reading both compress and common files) to replace original AfsFileSystem. 
Same as #24272